### PR TITLE
Add property.inferMany

### DIFF
--- a/src/properties/index.ts
+++ b/src/properties/index.ts
@@ -1,10 +1,12 @@
+import date from "./date";
 import dynamicImport from "./dynamicImport";
 import infer from "./infer";
-import date from "./date";
+import inferMany from "./inferMany";
 
 export {
-  infer,
+  date,
   dynamicImport,
-  date
+  infer,
+  inferMany
 };
 

--- a/src/properties/inferMany.ts
+++ b/src/properties/inferMany.ts
@@ -1,0 +1,12 @@
+import infer from "./infer";
+
+import { InferableObject } from "@posh/ast";
+import { ValueProperties } from "../types";
+
+export default function inferMany(values: InferableObject) {
+  const properties: { [key: string]: ValueProperties } = {};
+  for (let key in values) {
+    properties[key] = infer(values[key]);
+  }
+  return properties;
+}

--- a/tests/fileResource.spec.ts
+++ b/tests/fileResource.spec.ts
@@ -23,11 +23,17 @@ describe("fileResource", () => {
       },
       async transform(filename) {
         const module = require(filename);
+        const obj = {
+          one: "one",
+          two: 2,
+          three: ["red", "yellow", "orange"]
+        };
         return {
           source: property.dynamicImport(filename),
           title: property.infer(module.title),
           slug: property.infer(module.slug),
-          date: property.date(2000, 6, 8)
+          date: property.date(2000, 6, 8),
+          ...property.inferMany(obj)
         };
       },
       api: [
@@ -42,12 +48,18 @@ describe("fileResource", () => {
   source: () => import("../fixtures/pages/one.js"),
   title: "One",
   slug: "one",
-  date: new Date(2000, 6, 8)
+  date: new Date(2000, 6, 8),
+  one: "one",
+  two: 2,
+  three: ["red", "yellow", "orange"]
 }, {
   source: () => import("../fixtures/pages/two.js"),
   title: "Two",
   slug: "two",
-  date: new Date(2000, 6, 8)
+  date: new Date(2000, 6, 8),
+  one: "one",
+  two: 2,
+  three: ["red", "yellow", "orange"]
 }];
 
 const api = {

--- a/types/properties/index.d.ts
+++ b/types/properties/index.d.ts
@@ -1,4 +1,5 @@
+import date from "./date";
 import dynamicImport from "./dynamicImport";
 import infer from "./infer";
-import date from "./date";
-export { infer, dynamicImport, date };
+import inferMany from "./inferMany";
+export { date, dynamicImport, infer, inferMany };

--- a/types/properties/inferMany.d.ts
+++ b/types/properties/inferMany.d.ts
@@ -1,0 +1,5 @@
+import { InferableObject } from "@posh/ast";
+import { ValueProperties } from "../types";
+export default function inferMany(values: InferableObject): {
+    [key: string]: ValueProperties;
+};


### PR DESCRIPTION
This makes it easy to flatten an object by inferring all of its properties.

```js
const thing = {
  one: "one",
  two: 2
};

transform(...) {
  return {
    ...property.inferMany(thing),
    three: property.number(4)
  };
  // will result in an object with properties "one", "two", and "three"
}
```

If the object should maintain its shape, `property.infer` should be used.

```js

transform(...) {
  return {
    thing: property.infer(thing),
    three: property.number(4)
  };
  // will result in an object with properties "thing", and "three"
}
```